### PR TITLE
Refresca hero y portafolio para destacar PYMERP y canal de WhatsApp

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -71,16 +71,16 @@
             </div>
             <div>
                 <h4>Contacto</h4>
-                <ul class="small">
-                    <li>Email: <a href="mailto:ignacio@datakomerz.com">ignacio@datakomerz.com</a></li>
-                    <li>Teléfono: <a href="tel:+56984664812">+56 9 8466 4812</a></li>
-                    <li>WhatsApp: <a target="_blank" rel="noopener" href="https://wa.me/56984664812">https://wa.me/56984664812</a></li>
-                    <li>Dirección: Santiago, Chile</li>
+                <ul class="small footer-list">
+                    <li><span class="footer-label">Email</span><a href="mailto:ignacio@datakomerz.com">ignacio@datakomerz.com</a></li>
+                    <li><span class="footer-label">Teléfono</span><a href="tel:+56984664812">+56 9 8466 4812</a></li>
+                    <li><span class="footer-label">WhatsApp</span><a target="_blank" rel="noopener" href="https://wa.me/56984664812">wa.me/56984664812</a></li>
+                    <li><span class="footer-label">Dirección</span><span>Santiago, Chile</span></li>
                 </ul>
             </div>
             <div>
                 <h4>Enlaces</h4>
-                <ul class="small">
+                <ul class="small footer-list">
                     <li><a href="nosotros.html">Nosotros</a></li>
                     <li><a href="portafolio.html">Portafolio</a></li>
                     <li><a href="blog.html">Blog</a></li>
@@ -89,6 +89,22 @@
             </div>
         </div>
     </footer>
+
+    <button class="chat-trigger" type="button" onclick="openChat()" aria-haspopup="dialog" aria-controls="chatWidget">Chat</button>
+    <div class="chat-widget" id="chatWidget" role="dialog" aria-modal="false" aria-hidden="true">
+      <div class="chat-header">
+        <span class="chat-whatsapp-icon" aria-hidden="true"></span>
+        <div>
+          <p class="chat-title">WhatsApp • DataKomerz</p>
+          <p class="chat-subtitle">Ignacio responde en minutos</p>
+        </div>
+        <button class="chat-close" type="button" aria-label="Cerrar chat" onclick="closeChat()">×</button>
+      </div>
+      <div class="chat-body">
+        <div class="chat-bubble">Hola DataKomerz 👋 Me interesa impulsar mi negocio con soluciones digitales.</div>
+        <a class="chat-send" target="_blank" rel="noopener" href="https://wa.me/56984664812?text=Hola%20DataKomerz%20%F0%9F%91%8B%20Me%20interesa%20impulsar%20mi%20negocio%20con%20soluciones%20digitales.">Enviar a WhatsApp</a>
+      </div>
+    </div>
 
     <script src="js/main.js"></script>
 </body>

--- a/contacto.html
+++ b/contacto.html
@@ -59,16 +59,16 @@
             </div>
             <div>
                 <h4>Contacto</h4>
-                <ul class="small">
-                    <li>Email: <a href="mailto:ignacio@datakomerz.com">ignacio@datakomerz.com</a></li>
-                    <li>Teléfono: <a href="tel:+56984664812">+56 9 8466 4812</a></li>
-                    <li>WhatsApp: <a target="_blank" rel="noopener" href="https://wa.me/56984664812">https://wa.me/56984664812</a></li>
-                    <li>Dirección: Santiago, Chile</li>
+                <ul class="small footer-list">
+                    <li><span class="footer-label">Email</span><a href="mailto:ignacio@datakomerz.com">ignacio@datakomerz.com</a></li>
+                    <li><span class="footer-label">Teléfono</span><a href="tel:+56984664812">+56 9 8466 4812</a></li>
+                    <li><span class="footer-label">WhatsApp</span><a target="_blank" rel="noopener" href="https://wa.me/56984664812">wa.me/56984664812</a></li>
+                    <li><span class="footer-label">Dirección</span><span>Santiago, Chile</span></li>
                 </ul>
             </div>
             <div>
                 <h4>Enlaces</h4>
-                <ul class="small">
+                <ul class="small footer-list">
                     <li><a href="nosotros.html">Nosotros</a></li>
                     <li><a href="portafolio.html">Portafolio</a></li>
                     <li><a href="blog.html">Blog</a></li>
@@ -77,6 +77,22 @@
             </div>
         </div>
     </footer>
+
+    <button class="chat-trigger" type="button" onclick="openChat()" aria-haspopup="dialog" aria-controls="chatWidget">Chat</button>
+    <div class="chat-widget" id="chatWidget" role="dialog" aria-modal="false" aria-hidden="true">
+      <div class="chat-header">
+        <span class="chat-whatsapp-icon" aria-hidden="true"></span>
+        <div>
+          <p class="chat-title">WhatsApp • DataKomerz</p>
+          <p class="chat-subtitle">Ignacio responde en minutos</p>
+        </div>
+        <button class="chat-close" type="button" aria-label="Cerrar chat" onclick="closeChat()">×</button>
+      </div>
+      <div class="chat-body">
+        <div class="chat-bubble">Hola DataKomerz 👋 Me interesa impulsar mi negocio con soluciones digitales.</div>
+        <a class="chat-send" target="_blank" rel="noopener" href="https://wa.me/56984664812?text=Hola%20DataKomerz%20%F0%9F%91%8B%20Me%20interesa%20impulsar%20mi%20negocio%20con%20soluciones%20digitales.">Enviar a WhatsApp</a>
+      </div>
+    </div>
 
     <script src="js/main.js"></script>
 </body>

--- a/css/estilos.css
+++ b/css/estilos.css
@@ -427,6 +427,9 @@ footer .logo-img { height: 56px; filter: drop-shadow(0 10px 24px rgba(79,70,229,
     from { transform: rotate(0deg) translate3d(0,0,0); }
     to { transform: rotate(360deg) translate3d(0,0,0); }
 }
+@keyframes spin-glow {
+    to { transform: rotate(360deg); }
+}
 @keyframes glass-rise {
     0% { opacity: 0; transform: translateY(40px); }
     100% { opacity: 1; transform: translateY(0); }
@@ -440,15 +443,74 @@ footer .logo-img { height: 56px; filter: drop-shadow(0 10px 24px rgba(79,70,229,
 .section h2::after { content: ""; display: block; width: 68px; height: 2px; background: linear-gradient(90deg, rgba(34,211,238,0), rgba(34,211,238,0.6), rgba(34,211,238,0)); border-radius: 999px; margin: 0.7rem auto 0; }
 .section p.lead { color: rgba(226,232,240,0.72); margin-top: 0; max-width: 620px; margin-left: auto; margin-right: auto; font-size: 1.02rem; letter-spacing: 0.02em; }
 .cards { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 1.6rem; }
-.card { position: relative; background: rgba(2,6,23,0.72); border: 1px solid rgba(34,211,238,0.22); border-radius: 26px; padding: 1.5rem; box-shadow: 0 28px 55px rgba(2,6,23,0.45); overflow: hidden; backdrop-filter: blur(14px); transition: transform .5s var(--transition-soft), box-shadow .5s var(--transition-soft), border-color .5s ease; }
-.card::before { content: ""; position: absolute; width: 140px; height: 140px; top: -60px; right: -40px; background: radial-gradient(circle at 30% 30%, rgba(34,211,238,0.35), transparent 70%); transform: rotate(25deg); opacity: 0.45; transition: transform .5s var(--transition-soft), opacity .5s ease; }
-.card::after { content: ""; position: absolute; inset: 0; background: linear-gradient(150deg, rgba(34,211,238,0.2), transparent 45%, rgba(251,113,133,0.18)); opacity: 0; transition: opacity .4s ease; }
-.card:hover { transform: translateY(-8px) scale(1.01); box-shadow: 0 38px 68px rgba(2,6,23,0.65); border-color: rgba(34,211,238,0.45); }
-.card:hover::after { opacity: 1; }
-.card:hover::before { transform: translate(-16px, 26px) rotate(8deg); opacity: 0.75; }
-.card h3 { margin: 0.6rem 0 0.4rem; color: var(--acento); font-size: 1.2rem; position: relative; z-index: 1; text-transform: uppercase; letter-spacing: 0.08em; }
-.card p { color: rgba(226,232,240,0.68); font-size: 0.99rem; position: relative; z-index: 1; line-height: 1.6; }
-.icon { width: 56px; height: 56px; border-radius: 18px; background: linear-gradient(135deg, rgba(34,211,238,0.18), rgba(79,70,229,0.25)); display: grid; place-items: center; font-weight: 800; color: var(--acento); position: relative; z-index: 1; letter-spacing: 0.08em; }
+.card {
+    position: relative;
+    padding: 2rem 1.8rem;
+    border-radius: 18px;
+    overflow: hidden;
+    backdrop-filter: blur(16px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.75rem;
+    isolation: isolate;
+    transition: transform .55s var(--transition-soft), box-shadow .55s var(--transition-soft);
+}
+.card::before {
+    content: "";
+    position: absolute;
+    inset: -2px;
+    border-radius: 22px;
+    background: conic-gradient(from 0deg, rgba(34,211,238,0.75), rgba(79,70,229,0.6), rgba(251,113,133,0.75), rgba(34,211,238,0.75));
+    filter: blur(0.8px);
+    animation: spin-glow 7s linear infinite;
+    z-index: 0;
+}
+.card::after {
+    content: "";
+    position: absolute;
+    inset: 1.6px;
+    border-radius: 16px;
+    background: linear-gradient(160deg, rgba(2,6,23,0.92), rgba(15,23,42,0.72));
+    box-shadow: inset 0 0 0 1px rgba(148,163,184,0.18);
+    z-index: 0;
+    transition: opacity .45s ease;
+}
+.card:hover {
+    transform: translateY(-10px) scale(1.02);
+    box-shadow: 0 40px 85px rgba(2,6,23,0.6);
+}
+.card:hover::after {
+    opacity: 0.92;
+}
+.card > * { position: relative; z-index: 1; }
+.card h3 {
+    margin: 0.4rem 0 0.2rem;
+    color: var(--blanco);
+    font-size: 1.24rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+.card p {
+    color: rgba(226,232,240,0.74);
+    font-size: 1rem;
+    line-height: 1.65;
+}
+.card .icon {
+    width: 72px;
+    height: 72px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font-weight: 800;
+    font-family: var(--f-display);
+    letter-spacing: 0.12em;
+    background: radial-gradient(circle at 30% 30%, rgba(34,211,238,0.35), transparent 70%);
+    border: 1px solid rgba(34,211,238,0.45);
+    box-shadow: 0 16px 34px rgba(34,211,238,0.28);
+    color: var(--acento);
+}
 /* --- POR QUÉ ELEGIRNOS --- */
 .why { background: linear-gradient(130deg, rgba(34,211,238,0.18), rgba(79,70,229,0.3)); color: var(--blanco); border-radius: 32px; padding: 2.4rem; box-shadow: 0 38px 75px rgba(2,6,23,0.55); position: relative; overflow: hidden; border: 1px solid rgba(34,211,238,0.25); }
 .why::after { content: ""; position: absolute; width: 420px; height: 420px; border-radius: 50%; background: radial-gradient(circle, rgba(79,70,229,0.45), transparent 65%); top: -160px; right: -160px; opacity: 0.45; filter: blur(2px); }
@@ -515,6 +577,109 @@ footer .logo-img { height: 56px; filter: drop-shadow(0 10px 24px rgba(79,70,229,
 }
 .chat-trigger:hover::after { opacity: 1; }
 .chat-trigger:focus-visible { outline: 2px solid rgba(34,211,238,0.8); outline-offset: 3px; }
+.chat-widget {
+    position: fixed;
+    right: 24px;
+    bottom: 100px;
+    width: min(320px, calc(100% - 48px));
+    background: rgba(2,6,23,0.94);
+    border-radius: 22px;
+    border: 1px solid rgba(34,211,238,0.35);
+    box-shadow: 0 28px 65px rgba(2,6,23,0.65);
+    padding: 1.1rem 1.2rem 1.3rem;
+    display: grid;
+    gap: 1rem;
+    opacity: 0;
+    transform: translateY(16px) scale(0.96);
+    pointer-events: none;
+    transition: opacity .45s var(--transition-soft), transform .45s var(--transition-soft);
+    z-index: 220;
+}
+.chat-widget.is-open {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    pointer-events: auto;
+}
+.chat-header {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 0.8rem;
+    align-items: center;
+}
+.chat-whatsapp-icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: #25D366;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 16px 30px rgba(37,211,102,0.45);
+    position: relative;
+}
+.chat-whatsapp-icon::after {
+    content: "";
+    width: 20px;
+    height: 20px;
+    background: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"%3E%3Cpath fill="%23fff" d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.472-.149-.67.15-.198.297-.767.967-.94 1.165-.173.198-.347.223-.644.075-.297-.149-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.447-.52.149-.173.198-.297.298-.495.099-.198.05-.372-.025-.521-.075-.149-.669-1.611-.916-2.207-.242-.579-.487-.5-.67-.51-.173-.008-.372-.01-.571-.01-.198 0-.52.074-.793.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.066 2.875 1.213 3.074.149.198 2.1 3.204 5.077 4.487.709.306 1.262.489 1.693.626.712.227 1.36.195 1.872.118.571-.085 1.758-.718 2.006-1.411.248-.694.248-1.289.173-1.411-.074-.123-.272-.198-.57-.347z"/%3E%3Cpath fill="%23fff" d="M12.004 2.002C6.478 2.002 2 6.432 2 11.887c0 1.897.497 3.648 1.356 5.198L2 22l4.994-1.309c1.493.82 3.2 1.294 5.01 1.294 5.526 0 10.004-4.43 10.004-9.885 0-5.456-4.478-9.898-10.004-9.898zm0 17.955c-1.55 0-3.01-.41-4.265-1.185l-.305-.18-2.962.776.789-2.88-.198-.295c-.847-1.346-1.294-2.901-1.294-4.591 0-4.62 3.77-8.38 8.435-8.38 4.655 0 8.435 3.76 8.435 8.38 0 4.62-3.78 8.355-8.435 8.355z"/%3E%3C/svg%3E') no-repeat center/contain;
+}
+.chat-title { margin: 0; font-family: var(--f-display); letter-spacing: 0.24em; text-transform: uppercase; font-size: 0.78rem; color: var(--blanco); }
+.chat-subtitle { margin: 0; font-size: 0.82rem; color: rgba(226,232,240,0.68); }
+.chat-close {
+    background: transparent;
+    border: none;
+    color: rgba(226,232,240,0.7);
+    font-size: 1.4rem;
+    cursor: pointer;
+    line-height: 1;
+    transition: color .3s ease;
+}
+.chat-close:hover { color: var(--acento); }
+.chat-body { display: grid; gap: 0.9rem; }
+.chat-bubble {
+    background: rgba(37,211,102,0.16);
+    border: 1px solid rgba(37,211,102,0.4);
+    color: rgba(240,253,244,0.92);
+    border-radius: 18px;
+    padding: 0.9rem 1rem;
+    font-size: 0.96rem;
+    line-height: 1.6;
+    position: relative;
+}
+.chat-bubble::after {
+    content: "";
+    position: absolute;
+    bottom: -10px;
+    right: 18px;
+    width: 14px;
+    height: 14px;
+    background: inherit;
+    border: inherit;
+    clip-path: polygon(0 0, 100% 0, 100% 100%);
+}
+.chat-send {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    border-radius: 999px;
+    border: 1px solid rgba(34,211,238,0.55);
+    padding: 0.55rem 1.4rem;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    color: var(--acento);
+    background: rgba(34,211,238,0.12);
+    transition: background .4s ease, color .4s ease, transform .4s var(--transition-soft);
+}
+.chat-send:hover { background: rgba(34,211,238,0.24); color: var(--blanco); transform: translateY(-2px); }
+.chat-send::before {
+    content: "";
+    width: 16px;
+    height: 16px;
+    background: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="%2322d3ee" stroke-width="2"%3E%3Cpath stroke-linecap="round" stroke-linejoin="round" d="M5 12h14M12 5l7 7-7 7"/%3E%3C/svg%3E') no-repeat center/contain;
+}
 .dk-toast {
     position: fixed;
     right: 24px;
@@ -558,8 +723,13 @@ footer .logo-img { height: 56px; filter: drop-shadow(0 10px 24px rgba(79,70,229,
 /* --- FOOTER --- */
 footer { background: linear-gradient(135deg, rgba(2,6,23,0.95), rgba(15,23,42,0.92)); color: var(--blanco); margin-top: 2.8rem; padding: 2.4rem 0; border-top-left-radius: 24px; border-top-right-radius: 24px; border-top: 1px solid rgba(34,211,238,0.2); box-shadow: 0 -24px 60px rgba(2,6,23,0.65); }
 .footer-grid { display: grid; grid-template-columns: 1.2fr 1fr 1fr; gap: 1.4rem; }
+footer .footer-grid > div { display: grid; gap: 0.8rem; text-align: left; align-content: start; }
 footer a { color: rgba(226,232,240,0.8); text-decoration: none; transition: color .3s ease; }
 footer a:hover { color: var(--acento); text-decoration: underline; }
+.footer-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.45rem; text-align: left; }
+.footer-label { display: block; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.28em; color: rgba(148,163,184,0.82); margin-bottom: 0.2rem; }
+.footer-list li { display: grid; gap: 0.1rem; }
+.footer-list a, .footer-list span { justify-self: flex-start; }
 .small { font-size: 0.92rem; color: rgba(226,232,240,0.65); }
 /* --- RESPONSIVE --- */
 @media (max-width: 1080px){
@@ -596,6 +766,8 @@ footer a:hover { color: var(--acento); text-decoration: underline; }
     .why-grid { grid-template-columns: 1fr; }
     .cta { padding: 2rem; }
     .portfolio-cta { padding: 1.4rem; }
+    .chat-trigger { right: 16px; bottom: 16px; width: calc(100% - 32px); }
+    .chat-widget { right: 16px; bottom: 88px; width: calc(100% - 32px); }
 }
 @media (max-width: 540px){
     .navbar { gap: 0.8rem; }

--- a/index.html
+++ b/index.html
@@ -47,25 +47,25 @@
           <span class="eyebrow hero-eyebrow">Arquitectura digital radical</span>
           <h1 class="hero-title" aria-live="polite">
             <span class="hero-title-line">
-              <span class="hero-title-brush">Geometría digital,</span>
+              <span class="hero-title-brush">Desatamos el crecimiento</span>
             </span>
             <span class="hero-title-line">
-              <span class="hero-title-brush hero-title-brush--delay">impacto humano.</span>
+              <span class="hero-title-brush hero-title-brush--delay">exponencial de tu negocio</span>
             </span>
           </h1>
-          <p class="hero-tagline" data-typewriter="Convertimos datos en experiencias sensibles que se adaptan a cada usuario en tiempo real."></p>
+          <p class="hero-tagline" data-typewriter="Construimos software, protocolos y motores comerciales que impulsan tus emprendimientos."></p>
           <div class="cta-row">
             <a class="btn btn-primario" href="contacto.html">Solicita una consulta</a>
             <a class="btn btn-ghost" href="servicios.html">Ver servicios</a>
           </div>
           <div class="hero-insights">
             <div class="insight-card">
-              <span class="label">+48%</span>
-              <span class="sub">Conversiones curadas</span>
+              <span class="label">30+</span>
+              <span class="sub">Softwares y MVPs incubados</span>
             </div>
             <div class="insight-card">
-              <span class="label">9 países</span>
-              <span class="sub">Ecosistemas activados</span>
+              <span class="label">120+</span>
+              <span class="sub">Protocolos y playbooks comerciales</span>
             </div>
             <div class="insight-card">
               <span class="label">24/7</span>
@@ -119,25 +119,25 @@
     <section class="container section section-proyectos reveal">
       <div class="projects-intro">
         <span class="eyebrow">Proyectos y portafolio</span>
-        <h2>PYMER en acción</h2>
-        <p class="lead">Descubre los focos estratégicos que impulsan la plataforma PYMER para digitalizar a las pequeñas y medianas empresas.</p>
+        <h2>PYMERP en acción</h2>
+        <p class="lead">Descubre los focos estratégicos que impulsan PYMERP, el software en desarrollo que potencia la gestión integral de las pymes.</p>
       </div>
       <div class="projects-grid">
         <article class="project-card">
           <h3>ERP pensado en las PYMEs</h3>
         </article>
         <article class="project-card">
-          <h3>Clientes: páginas web</h3>
+          <h3>Clientes y diseño de páginas web</h3>
         </article>
         <article class="project-card">
-          <h3>Automatización empresarial</h3>
+          <h3>Automatización de sistemas</h3>
         </article>
         <article class="project-card">
-          <h3>Flujos y protocolos de trabajo</h3>
+          <h3>Manuales de flujos y protocolos</h3>
         </article>
       </div>
       <div class="portfolio-cta">
-        <p>Conoce cómo estas soluciones se integran para ofrecer una experiencia PYMER completa y escalable.</p>
+        <p>Conoce cómo estas soluciones se integran para ofrecer una experiencia PYMERP completa y escalable.</p>
         <a class="btn btn-ghost btn-ghost-strong" href="portafolio.html">Ver portafolio completo</a>
       </div>
     </section>
@@ -159,16 +159,16 @@
             </div>
             <div>
                 <h4>Contacto</h4>
-                <ul class="small">
-                    <li>Email: <a href="mailto:ignacio@datakomerz.com">ignacio@datakomerz.com</a></li>
-                    <li>Teléfono: <a href="tel:+56984664812">+56 9 8466 4812</a></li>
-                    <li>WhatsApp: <a target="_blank" rel="noopener" href="https://wa.me/56984664812">https://wa.me/56984664812</a></li>
-                    <li>Dirección: Santiago, Chile</li>
+                <ul class="small footer-list">
+                    <li><span class="footer-label">Email</span><a href="mailto:ignacio@datakomerz.com">ignacio@datakomerz.com</a></li>
+                    <li><span class="footer-label">Teléfono</span><a href="tel:+56984664812">+56 9 8466 4812</a></li>
+                    <li><span class="footer-label">WhatsApp</span><a target="_blank" rel="noopener" href="https://wa.me/56984664812">wa.me/56984664812</a></li>
+                    <li><span class="footer-label">Dirección</span><span>Santiago, Chile</span></li>
                 </ul>
             </div>
             <div>
                 <h4>Enlaces</h4>
-                <ul class="small">
+                <ul class="small footer-list">
                     <li><a href="nosotros.html">Nosotros</a></li>
                     <li><a href="portafolio.html">Portafolio</a></li>
                     <li><a href="blog.html">Blog</a></li>
@@ -178,7 +178,21 @@
         </div>
     </footer>
 
-    <button class="chat-trigger" onclick="openChat()">Chat</button>
+    <button class="chat-trigger" type="button" onclick="openChat()" aria-haspopup="dialog" aria-controls="chatWidget">Chat</button>
+    <div class="chat-widget" id="chatWidget" role="dialog" aria-modal="false" aria-hidden="true">
+      <div class="chat-header">
+        <span class="chat-whatsapp-icon" aria-hidden="true"></span>
+        <div>
+          <p class="chat-title">WhatsApp • DataKomerz</p>
+          <p class="chat-subtitle">Ignacio responde en minutos</p>
+        </div>
+        <button class="chat-close" type="button" aria-label="Cerrar chat" onclick="closeChat()">×</button>
+      </div>
+      <div class="chat-body">
+        <div class="chat-bubble">Hola DataKomerz 👋 Me interesa impulsar mi negocio con soluciones digitales.</div>
+        <a class="chat-send" target="_blank" rel="noopener" href="https://wa.me/56984664812?text=Hola%20DataKomerz%20%F0%9F%91%8B%20Me%20interesa%20impulsar%20mi%20negocio%20con%20soluciones%20digitales.">Enviar a WhatsApp</a>
+      </div>
+    </div>
     <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,10 @@
 // Interacciones y animaciones de la portada DataKomerz
 (function(){
   const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  let chatWidget;
+  let chatCloseBtn;
+  let chatSendLink;
+  const CHAT_MESSAGE = 'Hola DataKomerz 👋 Me interesa impulsar mi negocio con soluciones digitales.';
 
   const createToast = (message) => {
     if (!message) return;
@@ -117,9 +121,58 @@
     runTypewriter();
     runReveal();
     runHeroParallax();
+
+    chatWidget = document.getElementById('chatWidget');
+    if (chatWidget) {
+      chatCloseBtn = chatWidget.querySelector('.chat-close');
+      chatSendLink = chatWidget.querySelector('.chat-send');
+      chatWidget.setAttribute('aria-hidden', 'true');
+
+      if (chatCloseBtn) {
+        chatCloseBtn.addEventListener('click', () => {
+          closeChat();
+        });
+      }
+
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && chatWidget.classList.contains('is-open')) {
+          closeChat();
+        }
+      });
+    }
   });
 
-  window.openChat = () => {
-    createToast('Hola 👋 Somos DataKomerz. Envíanos un mensaje y diseñemos experiencias geométricas juntos.');
+  const toggleChat = (open) => {
+    if (!chatWidget) {
+      createToast('Hola 👋 Somos DataKomerz. Envíanos un mensaje y diseñemos experiencias geométricas juntos.');
+      return;
+    }
+
+    chatWidget.classList.toggle('is-open', open);
+    chatWidget.setAttribute('aria-hidden', open ? 'false' : 'true');
+
+    if (open) {
+      createToast('Listo para conversar por WhatsApp 🚀');
+      const bubble = chatWidget.querySelector('.chat-bubble');
+      if (bubble) {
+        bubble.textContent = CHAT_MESSAGE;
+      }
+      if (chatSendLink) {
+        chatSendLink.setAttribute('href', `https://wa.me/56984664812?text=${encodeURIComponent(CHAT_MESSAGE)}`);
+        window.setTimeout(() => chatSendLink.focus(), 120);
+      }
+    }
   };
+
+  const openChat = () => {
+    const shouldOpen = !chatWidget || !chatWidget.classList.contains('is-open');
+    toggleChat(shouldOpen);
+  };
+
+  const closeChat = () => {
+    toggleChat(false);
+  };
+
+  window.openChat = openChat;
+  window.closeChat = closeChat;
 })();

--- a/nosotros.html
+++ b/nosotros.html
@@ -53,16 +53,16 @@
             </div>
             <div>
                 <h4>Contacto</h4>
-                <ul class="small">
-                    <li>Email: <a href="mailto:ignacio@datakomerz.com">ignacio@datakomerz.com</a></li>
-                    <li>Teléfono: <a href="tel:+56984664812">+56 9 8466 4812</a></li>
-                    <li>WhatsApp: <a target="_blank" rel="noopener" href="https://wa.me/56984664812">https://wa.me/56984664812</a></li>
-                    <li>Dirección: Santiago, Chile</li>
+                <ul class="small footer-list">
+                    <li><span class="footer-label">Email</span><a href="mailto:ignacio@datakomerz.com">ignacio@datakomerz.com</a></li>
+                    <li><span class="footer-label">Teléfono</span><a href="tel:+56984664812">+56 9 8466 4812</a></li>
+                    <li><span class="footer-label">WhatsApp</span><a target="_blank" rel="noopener" href="https://wa.me/56984664812">wa.me/56984664812</a></li>
+                    <li><span class="footer-label">Dirección</span><span>Santiago, Chile</span></li>
                 </ul>
             </div>
             <div>
                 <h4>Enlaces</h4>
-                <ul class="small">
+                <ul class="small footer-list">
                     <li><a href="nosotros.html">Nosotros</a></li>
                     <li><a href="portafolio.html">Portafolio</a></li>
                     <li><a href="blog.html">Blog</a></li>
@@ -71,6 +71,22 @@
             </div>
         </div>
     </footer>
+
+    <button class="chat-trigger" type="button" onclick="openChat()" aria-haspopup="dialog" aria-controls="chatWidget">Chat</button>
+    <div class="chat-widget" id="chatWidget" role="dialog" aria-modal="false" aria-hidden="true">
+      <div class="chat-header">
+        <span class="chat-whatsapp-icon" aria-hidden="true"></span>
+        <div>
+          <p class="chat-title">WhatsApp • DataKomerz</p>
+          <p class="chat-subtitle">Ignacio responde en minutos</p>
+        </div>
+        <button class="chat-close" type="button" aria-label="Cerrar chat" onclick="closeChat()">×</button>
+      </div>
+      <div class="chat-body">
+        <div class="chat-bubble">Hola DataKomerz 👋 Me interesa impulsar mi negocio con soluciones digitales.</div>
+        <a class="chat-send" target="_blank" rel="noopener" href="https://wa.me/56984664812?text=Hola%20DataKomerz%20%F0%9F%91%8B%20Me%20interesa%20impulsar%20mi%20negocio%20con%20soluciones%20digitales.">Enviar a WhatsApp</a>
+      </div>
+    </div>
 
     <script src="js/main.js"></script>
 </body>

--- a/portafolio.html
+++ b/portafolio.html
@@ -36,11 +36,12 @@
 
     <section class="container section">
       <h2>Portafolio de proyectos</h2>
-      <p class="lead">Diseñamos productos digitales, funnels y plataformas data-driven que desafían el status quo y generan impacto inmediato.</p>
+      <p class="lead">Diseñamos software, experiencias y sistemas comerciales que escalan emprendimientos con una visión integral.</p>
       <div class="cards">
-        <div class="card"><h3>Escalamiento E-commerce</h3><p>Arquitectura headless, optimización Core Web Vitals y experiencias hiperpersonalizadas que triplicaron la facturación mensual.</p></div>
-        <div class="card"><h3>Lead Gen B2B</h3><p>Automatizaciones de nurturing, scoring predictivo y dashboards ejecutivos que multiplicaron por 3.2 los MQLs calificados.</p></div>
-        <div class="card"><h3>Data Foundation</h3><p>Implementamos un stack de datos modular (ETL + BI + IA) en 6 semanas para decisiones accionables en toda la organización.</p></div>
+        <div class="card"><h3>PYMERP — Gestión integral</h3><p>Software ERP modular en desarrollo para digitalizar finanzas, ventas y operaciones de las pymes desde una sola consola.</p></div>
+        <div class="card"><h3>Clientes y páginas web</h3><p>Diseño UX/UI, desarrollo y despliegue de sitios corporativos y landings optimizadas para la conversión.</p></div>
+        <div class="card"><h3>Manuales y protocolos</h3><p>Documentamos flujos críticos, roles y SLAs para estandarizar la operación y acelerar la incorporación de equipos.</p></div>
+        <div class="card"><h3>Automatización de sistemas</h3><p>Integraciones, bots y tableros que conectan marketing, ventas y soporte para decisiones en tiempo real.</p></div>
       </div>
       <p class="small" style="margin-top:1rem">¿Quieres ver más? <a href="contacto.html">Solicita el portafolio completo</a>.</p>
     </section>
@@ -54,16 +55,16 @@
             </div>
             <div>
                 <h4>Contacto</h4>
-                <ul class="small">
-                    <li>Email: <a href="mailto:ignacio@datakomerz.com">ignacio@datakomerz.com</a></li>
-                    <li>Teléfono: <a href="tel:+56984664812">+56 9 8466 4812</a></li>
-                    <li>WhatsApp: <a target="_blank" rel="noopener" href="https://wa.me/56984664812">https://wa.me/56984664812</a></li>
-                    <li>Dirección: Santiago, Chile</li>
+                <ul class="small footer-list">
+                    <li><span class="footer-label">Email</span><a href="mailto:ignacio@datakomerz.com">ignacio@datakomerz.com</a></li>
+                    <li><span class="footer-label">Teléfono</span><a href="tel:+56984664812">+56 9 8466 4812</a></li>
+                    <li><span class="footer-label">WhatsApp</span><a target="_blank" rel="noopener" href="https://wa.me/56984664812">wa.me/56984664812</a></li>
+                    <li><span class="footer-label">Dirección</span><span>Santiago, Chile</span></li>
                 </ul>
             </div>
             <div>
                 <h4>Enlaces</h4>
-                <ul class="small">
+                <ul class="small footer-list">
                     <li><a href="nosotros.html">Nosotros</a></li>
                     <li><a href="portafolio.html">Portafolio</a></li>
                     <li><a href="blog.html">Blog</a></li>
@@ -72,6 +73,22 @@
             </div>
         </div>
     </footer>
+
+    <button class="chat-trigger" type="button" onclick="openChat()" aria-haspopup="dialog" aria-controls="chatWidget">Chat</button>
+    <div class="chat-widget" id="chatWidget" role="dialog" aria-modal="false" aria-hidden="true">
+      <div class="chat-header">
+        <span class="chat-whatsapp-icon" aria-hidden="true"></span>
+        <div>
+          <p class="chat-title">WhatsApp • DataKomerz</p>
+          <p class="chat-subtitle">Ignacio responde en minutos</p>
+        </div>
+        <button class="chat-close" type="button" aria-label="Cerrar chat" onclick="closeChat()">×</button>
+      </div>
+      <div class="chat-body">
+        <div class="chat-bubble">Hola DataKomerz 👋 Me interesa impulsar mi negocio con soluciones digitales.</div>
+        <a class="chat-send" target="_blank" rel="noopener" href="https://wa.me/56984664812?text=Hola%20DataKomerz%20%F0%9F%91%8B%20Me%20interesa%20impulsar%20mi%20negocio%20con%20soluciones%20digitales.">Enviar a WhatsApp</a>
+      </div>
+    </div>
 
     <script src="js/main.js"></script>
 </body>

--- a/servicios.html
+++ b/servicios.html
@@ -56,16 +56,16 @@
             </div>
             <div>
                 <h4>Contacto</h4>
-                <ul class="small">
-                    <li>Email: <a href="mailto:ignacio@datakomerz.com">ignacio@datakomerz.com</a></li>
-                    <li>Teléfono: <a href="tel:+56984664812">+56 9 8466 4812</a></li>
-                    <li>WhatsApp: <a target="_blank" rel="noopener" href="https://wa.me/56984664812">https://wa.me/56984664812</a></li>
-                    <li>Dirección: Santiago, Chile</li>
+                <ul class="small footer-list">
+                    <li><span class="footer-label">Email</span><a href="mailto:ignacio@datakomerz.com">ignacio@datakomerz.com</a></li>
+                    <li><span class="footer-label">Teléfono</span><a href="tel:+56984664812">+56 9 8466 4812</a></li>
+                    <li><span class="footer-label">WhatsApp</span><a target="_blank" rel="noopener" href="https://wa.me/56984664812">wa.me/56984664812</a></li>
+                    <li><span class="footer-label">Dirección</span><span>Santiago, Chile</span></li>
                 </ul>
             </div>
             <div>
                 <h4>Enlaces</h4>
-                <ul class="small">
+                <ul class="small footer-list">
                     <li><a href="nosotros.html">Nosotros</a></li>
                     <li><a href="portafolio.html">Portafolio</a></li>
                     <li><a href="blog.html">Blog</a></li>
@@ -74,6 +74,22 @@
             </div>
         </div>
     </footer>
+
+    <button class="chat-trigger" type="button" onclick="openChat()" aria-haspopup="dialog" aria-controls="chatWidget">Chat</button>
+    <div class="chat-widget" id="chatWidget" role="dialog" aria-modal="false" aria-hidden="true">
+      <div class="chat-header">
+        <span class="chat-whatsapp-icon" aria-hidden="true"></span>
+        <div>
+          <p class="chat-title">WhatsApp • DataKomerz</p>
+          <p class="chat-subtitle">Ignacio responde en minutos</p>
+        </div>
+        <button class="chat-close" type="button" aria-label="Cerrar chat" onclick="closeChat()">×</button>
+      </div>
+      <div class="chat-body">
+        <div class="chat-bubble">Hola DataKomerz 👋 Me interesa impulsar mi negocio con soluciones digitales.</div>
+        <a class="chat-send" target="_blank" rel="noopener" href="https://wa.me/56984664812?text=Hola%20DataKomerz%20%F0%9F%91%8B%20Me%20interesa%20impulsar%20mi%20negocio%20con%20soluciones%20digitales.">Enviar a WhatsApp</a>
+      </div>
+    </div>
 
     <script src="js/main.js"></script>
 </body>


### PR DESCRIPTION
## Resumen
- Actualicé el hero con mensajes centrados en crecimiento exponencial, nuevas métricas de software y reforcé la sección de proyectos resaltando PYMERP.
- Modernicé el diseño de tarjetas con efecto de iluminación rotatoria y reorganicé los pies de página para mostrar los datos de contacto alineados.
- Implementé un widget de chat con icono de WhatsApp, mensaje prellenado y controles de apertura/cierre reutilizables en todas las páginas.

## Pruebas
- Sin pruebas automatizadas disponibles.

------
https://chatgpt.com/codex/tasks/task_b_68d43abb209083309ed376207db4b8ea